### PR TITLE
fix segfault on exit and BA namespaces

### DIFF
--- a/include/svo/slamviewer.h
+++ b/include/svo/slamviewer.h
@@ -19,6 +19,7 @@ public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   
   Viewer(  svo::FrameHandlerMono* vo);
+  ~Viewer();
   void run();
   bool CheckFinish();
   void DrawKeyFrames(const bool bDrawKF);
@@ -39,6 +40,10 @@ private:
   void SetFinish();
   bool mbFinished;
   std::mutex mMutexFinish;
+
+  bool CheckFinish2();
+  bool mbFinished2;
+  std::mutex mMutexFinish2;
 
   float mKeyFrameSize;
   float mKeyFrameLineWidth;

--- a/src/bundle_adjustment.cpp
+++ b/src/bundle_adjustment.cpp
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#include <vikit/math_utils.h>
+#include <svo/math_lib.h>
 #include <boost/thread.hpp>
 #include <g2o/core/sparse_optimizer.h>
 #include <g2o/core/block_solver.h>
@@ -71,13 +71,13 @@ void twoViewBA(
     g2oPoint* v_pt = createG2oPoint(pt->pos_, v_id++, false);
     optimizer.addVertex(v_pt);
     pt->v_pt_ = v_pt;
-    g2oEdgeSE3* e = createG2oEdgeSE3(v_frame1, v_pt, vk::project2d((*it_ftr)->f), true, reproj_thresh*Config::lobaRobustHuberWidth());
+    g2oEdgeSE3* e = createG2oEdgeSE3(v_frame1, v_pt, svo::project2d((*it_ftr)->f), true, reproj_thresh*Config::lobaRobustHuberWidth());
     optimizer.addEdge(e);
     edges.push_back(EdgeContainerSE3(e, frame1, *it_ftr)); // TODO feature now links to frame, so we can simplify edge container!
 
     // find at which index the second frame observes the point
     Feature* ftr_frame2 = pt->findFrameRef(frame2);
-    e = createG2oEdgeSE3(v_frame2, v_pt, vk::project2d(ftr_frame2->f), true, reproj_thresh*Config::lobaRobustHuberWidth());
+    e = createG2oEdgeSE3(v_frame2, v_pt, svo::project2d(ftr_frame2->f), true, reproj_thresh*Config::lobaRobustHuberWidth());
     optimizer.addEdge(e);
     edges.push_back(EdgeContainerSE3(e, frame2, ftr_frame2));
   }
@@ -175,7 +175,7 @@ void localBA(
     list<Feature*>::iterator it_obs=(*it_pt)->obs_.begin();
     while(it_obs!=(*it_pt)->obs_.end())
     {
-      Vector2d error = vk::project2d((*it_obs)->f) - vk::project2d((*it_obs)->frame->w2f((*it_pt)->pos_));
+      Vector2d error = svo::project2d((*it_obs)->f) - svo::project2d((*it_obs)->frame->w2f((*it_pt)->pos_));
 
       if((*it_obs)->frame->v_kf_ == NULL)
       {
@@ -190,7 +190,7 @@ void localBA(
 
       // create edge
       g2oEdgeSE3* e = createG2oEdgeSE3((*it_obs)->frame->v_kf_, v_pt,
-                                       vk::project2d((*it_obs)->f),
+                                       svo::project2d((*it_obs)->f),
                                        true,
                                        reproj_thresh_2*Config::lobaRobustHuberWidth(),
                                        1.0 / (1<<(*it_obs)->level));
@@ -288,12 +288,12 @@ void globalBA(Map* map)
 
       // Due to merging of mappoints it is possible that references in kfs suddenly
       // have a very large reprojection error which may result in distorted results.
-      Vector2d error = vk::project2d((*it_ftr)->f) - vk::project2d((*it_kf)->w2f(mp->pos_));
+      Vector2d error = svo::project2d((*it_ftr)->f) - svo::project2d((*it_kf)->w2f(mp->pos_));
       if(error.squaredNorm() > reproj_thresh_1_squared)
         incorrect_edges.push_back(pair<FramePtr,Feature*>(*it_kf, *it_ftr));
       else
       {
-        g2oEdgeSE3* e = createG2oEdgeSE3(v_kf, v_mp, vk::project2d((*it_ftr)->f),
+        g2oEdgeSE3* e = createG2oEdgeSE3(v_kf, v_mp, svo::project2d((*it_ftr)->f),
                                          true,
                                          reproj_thresh_2*Config::lobaRobustHuberWidth());
 

--- a/src/slamviewer.cpp
+++ b/src/slamviewer.cpp
@@ -13,6 +13,7 @@ Viewer::Viewer( svo::FrameHandlerMono* vo):
 {
 
   mbFinished = false;
+  mbFinished2 = false;
   mViewpointX =  0;
   mViewpointY = -0.7;
   mViewpointZ =  -1.8;
@@ -27,10 +28,24 @@ Viewer::Viewer( svo::FrameHandlerMono* vo):
 
 }
 
+Viewer::~Viewer()
+{
+  SetFinish();
+
+  while (!CheckFinish2())
+    usleep(5000);
+}
+
 bool Viewer::CheckFinish()
 {
     std::unique_lock<std::mutex> lock(mMutexFinish);
     return mbFinished;
+}
+
+bool Viewer::CheckFinish2()
+{
+  std::unique_lock<std::mutex> lock(mMutexFinish2);
+  return mbFinished2;
 }
 
 void Viewer::SetFinish()
@@ -363,6 +378,10 @@ void Viewer::run()
   pangolin::BindToContext("SVO: trajactory viewer");
   std::cout<<"pangolin close"<<std::endl;
 
+  {
+    std::unique_lock<std::mutex> lock(mMutexFinish2);
+    mbFinished2 = true;
+  }
 }
 
 }

--- a/test/test_pipel_euroc.cpp
+++ b/test/test_pipel_euroc.cpp
@@ -93,7 +93,7 @@ BenchmarkNode::~BenchmarkNode()
   delete vo_;
   delete cam_;
   delete cam_r_;
-  delete cam_pinhole_;
+  // delete cam_pinhole_;
 
   delete viewer_;
   delete viewer_thread_;

--- a/test/test_pipeline.cpp
+++ b/test/test_pipeline.cpp
@@ -108,7 +108,7 @@ BenchmarkNode::~BenchmarkNode()
 {
   delete vo_;
   delete cam_;
-  delete cam_pinhole_;
+  // delete cam_pinhole_;
 
   delete viewer_;
   delete viewer_thread_;


### PR DESCRIPTION
1. In the viewer, a destructor is added to ensure Pangolin exits properly before it is destructed. 
2. In the BA source code, since `vikit` is not imported, I use `svo/math_lib.h` and rename the namespaces. 
3. Lastly, since `cam_pinhole_` is not being used in the test code, I have removed them to prevent the program from crashing